### PR TITLE
JB-29-restrictOtherDomains

### DIFF
--- a/src/controllers/Auth.controller.ts
+++ b/src/controllers/Auth.controller.ts
@@ -47,6 +47,11 @@ export const AuthResolvers = {
 		newUser: async (_: any, { userInput }: UserInput, ctx: CustomContext): Promise<User> => {
 			const { email } = userInput;
 
+
+			if (!(/@jardinbinario.com\s*$/.test(email))) {
+				throw await generateErrorObject(Errors.NOT_VALID_DOMAIN, `${email} does not have a valid domain.`, ctx);
+			}
+
 			const User = await findUserByEmail(email);
 
 			if (User) {
@@ -73,14 +78,8 @@ export const AuthResolvers = {
 			}
 
 			try {
-				const token = await generateJWT(
-					User as User,
-					String(process.env.PRIVATE_KEY),
-					String(process.env.EXPIRATION_TIME)
-				);
-				return {
-					token,
-				};
+				const token = generateJWT(User as User);
+				return { token };
 			} catch (err) {
 				throw await generateErrorObject(Errors.INTERNAL_SERVER_ERROR, String(err), ctx);
 			}

--- a/src/helpers/Logger.ts
+++ b/src/helpers/Logger.ts
@@ -33,7 +33,7 @@ export const Errors = {
 	},
 	WRONG_INPUT: {
 		code: 'WRONG_INPUT',
-		notify: true,
+		notify: false,
 	},
 	SMTP_ERROR: {
 		code: 'SMTP_ERROR',
@@ -45,6 +45,10 @@ export const Errors = {
 	},
 	SESSION_EXPIRED: {
 		code: 'SESSION_EXPIRED',
+		notify: false,
+	},
+	NOT_VALID_DOMAIN: {
+		code: 'NOT_VALID_DOMAIN',
 		notify: false,
 	}
 };

--- a/src/helpers/authFunctions.ts
+++ b/src/helpers/authFunctions.ts
@@ -1,14 +1,14 @@
 import { sign, verify } from 'jsonwebtoken';
 import { Token, User } from '../types/sharedTypes';
 
-export const generateJWT = async ({ name, lastName, id, email, avatar }: User, privateKey: string, expiration: string): Promise<Token['token']> => {
-	const jwt = await sign({ name, lastName, id, email, avatar }, privateKey, {
-		expiresIn: expiration,
+export const generateJWT = ({ name, lastName, id, email, avatar }: User): Token['token'] => {
+	const jwt = sign({ name, lastName, id, email, avatar }, String(process.env.PRIVATE_KEY), {
+		expiresIn: String(process.env.EXPIRATION_TIME),
 	});
 	return jwt;
 };
 
-export const verifyJWT = async (token: string): Promise<User> => {
-	const payload = await verify(token, String(process.env.PRIVATE_KEY));
+export const verifyJWT = (token: string): User => {
+	const payload = verify(token, String(process.env.PRIVATE_KEY));
 	return payload as User;
 };

--- a/src/helpers/getCustomContext.ts
+++ b/src/helpers/getCustomContext.ts
@@ -59,7 +59,7 @@ export const getCustomContext = async (req: Request): Promise<CustomContext | Ta
 	if (!token || tokenWithoutBearer === '') throw new Error('A verification token is required.');
 
 	try {
-		const User = await verifyJWT(tokenWithoutBearer);
+		const User = verifyJWT(tokenWithoutBearer);
 
 		if (!User) {
 			throw await generateErrorObject(Errors.UNKOWN_USER, 'Not a valid user', taggedContext);


### PR DESCRIPTION
made JWT functions sync, don't know why they were async before, added a check to only allow `jardinbinario` emails to pass through